### PR TITLE
Add csm-high-priority-service pod priority class to speaker pods

### DIFF
--- a/kubernetes/cray-metallb/templates/speaker.yaml
+++ b/kubernetes/cray-metallb/templates/speaker.yaml
@@ -29,6 +29,9 @@ spec:
 {{- end }}
     spec:
       serviceAccountName: {{ template "metallb.speakerServiceAccountName" . }}
+{{- if .Values.speaker.priorityClassName }}
+      priorityClassName: {{ .Values.speaker.priorityClassName }}
+{{- end }}
       terminationGracePeriodSeconds: 0
       hostNetwork: true
 {{- if gt (len .Values.speaker.initContainers) 0 }}

--- a/kubernetes/cray-metallb/values.yaml
+++ b/kubernetes/cray-metallb/values.yaml
@@ -108,6 +108,7 @@ controller:
 # speaker contains configuration specific to the MetalLB speaker
 # daemonset.
 speaker:
+  priorityClassName: csm-high-priority-service
   image:
     repository: metallb/speaker
     tag: v0.8.1


### PR DESCRIPTION
### Summary and Scope

Add pod priority support to speaker pods

### Issues and Related PRs

* CASMPET-4413

### Testing

* vshasta

```
ncn-m001-21f512b8:/home/bklein # kubectl get po cray-metallb-speaker-2g4cn -n metallb-system -o yaml | grep prior
        f:priorityClassName: {}
  priority: 1000000
  priorityClassName: csm-high-priority-service
```

Was a fresh Install tested? N
Was an Upgrade tested?      N
Was a Downgrade tested?     N
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations

Low

### Requires:

* Fresh install