### PR TITLE
CASMMON-411  victoria-metrics broke metallb deployment

### DIFF
--- a/charts/cray-metallb/Chart.yaml
+++ b/charts/cray-metallb/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-metallb
-version: 1.2.0
+version: 1.2.1
 description: MetalLB is a load-balancer implementation for bare metal Kubernetes clusters
 home: https://github.com/Cray-HPE/cray-metallb
 dependencies:

--- a/charts/cray-metallb/templates/metallb-controller.yaml
+++ b/charts/cray-metallb/templates/metallb-controller.yaml
@@ -1,0 +1,21 @@
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMPodScrape
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: cray-metallb
+  name: metallb-controller
+  namespace: metallb-system
+spec:
+  jobLabel: app.kubernetes.io/name
+  namespaceSelector:
+    matchNames:
+    - metallb-system
+  podMetricsEndpoints:
+  - path: /metrics
+    port: metrics
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: controller
+      app.kubernetes.io/instance: cray-metallb
+      app.kubernetes.io/name: metallb

--- a/charts/cray-metallb/templates/metallb-speaker.yaml
+++ b/charts/cray-metallb/templates/metallb-speaker.yaml
@@ -1,0 +1,21 @@
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMPodScrape
+metadata:
+  labels:
+    app.kubernetes.io/component: speaker
+    app.kubernetes.io/instance: cray-metallb
+  name: metallb-speaker
+  namespace: metallb-system
+spec:
+  jobLabel: app.kubernetes.io/name
+  namespaceSelector:
+    matchNames:
+    - metallb-system
+  podMetricsEndpoints:
+  - path: /metrics
+    port: metrics
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: speaker
+      app.kubernetes.io/instance: cray-metallb
+      app.kubernetes.io/name: metallb

--- a/charts/cray-metallb/templates/metallb.yaml
+++ b/charts/cray-metallb/templates/metallb.yaml
@@ -1,0 +1,68 @@
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMRule
+metadata:
+  labels:
+    app.kubernetes.io/instance: cray-metallb
+    app.kubernetes.io/name: metallb
+  name: metallb
+  namespace: metallb-system
+spec:
+  groups:
+  - name: metallb.rules
+    rules:
+    - alert: MetalLBStaleConfig
+      annotations:
+        message: '"{{`{{ $labels.job }}`}}" - MetalLB "{{`{{ $labels.container }}`}}" on "{{`{{ $labels.pod
+          }}`}}" has a stale config for > 1 minute'
+      expr: metallb_k8s_client_config_stale_bool{job="metallb"} == 1
+      for: 1m
+      labels:
+        severity: warning
+    - alert: MetalLBConfigNotLoaded
+      annotations:
+        message: '"{{`{{ $labels.job }}`}}" - MetalLB "{{`{{ $labels.container }}`}}" on "{{`{{ $labels.pod
+          }}`}}" has not loaded for > 1 minute'
+      expr: metallb_k8s_client_config_loaded_bool{job="metallb"} == 0
+      for: 1m
+      labels:
+        severity: warning
+    - alert: MetalLBAddressPoolExhausted
+      annotations:
+        message: '"{{`{{ $labels.job }}`}}" - MetalLB "{{`{{ $labels.container }}`}}" on "{{`{{ $labels.pod
+          }}`}}" has exhausted address pool "{{`{{ $labels.pool }}`}}" for > 1 minute'
+      expr: metallb_allocator_addresses_in_use_total >= on(pool) metallb_allocator_addresses_total
+      for: 1m
+      labels:
+        severity: alert
+    - alert: MetalLBAddressPoolUsage75Percent
+      annotations:
+        message: '"{{`{{ $labels.job }}`}}" - MetalLB "{{`{{ $labels.container }}`}}" on "{{`{{ $labels.pod
+          }}`}}" has address pool "{{`{{ $labels.pool }}`}}" past 75% usage for > 1 minute'
+      expr: ( metallb_allocator_addresses_in_use_total / on(pool) metallb_allocator_addresses_total
+        ) * 100 > 75
+      labels:
+        severity: warning
+    - alert: MetalLBAddressPoolUsage85Percent
+      annotations:
+        message: '"{{`{{ $labels.job }}`}}" - MetalLB "{{`{{ $labels.container }}`}}" on "{{`{{ $labels.pod
+          }}`}}" has address pool "{{`{{ $labels.pool }}`}}" past 85% usage for > 1 minute'
+      expr: ( metallb_allocator_addresses_in_use_total / on(pool) metallb_allocator_addresses_total
+        ) * 100 > 85
+      labels:
+        severity: warning
+    - alert: MetalLBAddressPoolUsage95Percent
+      annotations:
+        message: '"{{`{{ $labels.job }}`}}" - MetalLB "{{`{{ $labels.container }}`}}" on "{{`{{ $labels.pod
+          }}`}}" has address pool "{{`{{ $labels.pool }}`}}" past 95% usage for > 1 minute'
+      expr: ( metallb_allocator_addresses_in_use_total / on(pool) metallb_allocator_addresses_total
+        ) * 100 > 95
+      labels:
+        severity: alert
+    - alert: MetalLBBGPSessionDown
+      annotations:
+        message: '"{{`{{ $labels.job }}`}}" - MetalLB "{{`{{ $labels.container }}`}}" on "{{`{{ $labels.pod
+          }}`}}" has BGP session "{{`{{ $labels.peer }}`}}" down for > 1 minute'
+      expr: metallb_bgp_session_up{job="metallb"} == 0
+      for: 1m
+      labels:
+        severity: alert

--- a/charts/cray-metallb/values.yaml
+++ b/charts/cray-metallb/values.yaml
@@ -30,9 +30,9 @@ metallb:
   prometheus:
     scrapeAnnotations: true
     prometheusRule:
-      enabled: true
+      enabled: false
     podMonitor:
-      enabled: true
+      enabled: false
   controller:
     image:
       registry: ""


### PR DESCRIPTION
## Summary and Scope

victoria-metrics broke metallb deployment

## Issues and Related PRs

https://jira-pro.it.hpe.com:8443/browse/CASMMON-411

## Testing

_List the environments in which these changes were tested._

### Tested on: fanta

ncn-m001:/mnt/developer/ram/metallb # kubectl get vmrules.operator.victoriametrics.com -n metallb-system
NAME      AGE
metallb   22s
ncn-m001:/mnt/developer/ram/metallb # kubectl get vmpodscrapes.operator.victoriametrics.com -n metallb-system
NAME                 AGE
metallb-controller   58s
metallb-speaker      58s


![image](https://github.com/Cray-HPE/cray-metallb/assets/22464568/0720715f-5b84-42d8-9ddf-e03c1dd05d50)
