### PR TITLE
CASMPET-7504: Switch to kubectl 1.24.17

### DIFF
--- a/charts/cray-metallb/Chart.yaml
+++ b/charts/cray-metallb/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-metallb
-version: 2.0.0
+version: 2.0.1
 description: MetalLB is a load-balancer implementation for bare metal Kubernetes clusters
 home: https://github.com/Cray-HPE/cray-metallb
 dependencies:

--- a/charts/cray-metallb/Chart.yaml
+++ b/charts/cray-metallb/Chart.yaml
@@ -37,7 +37,7 @@ appVersion: v0.14.9
 annotations:
   artifacthub.io/images: |-
     - name: kubectl
-      image: artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.32.2
+      image: artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.24.17
     - name: metallb-controller
       image: artifactory.algol60.net/csm-docker/stable/quay.io/metallb/controller:v0.14.9
     - name: metallb-speaker

--- a/charts/cray-metallb/templates/post-install-apply-crds-job.yaml
+++ b/charts/cray-metallb/templates/post-install-apply-crds-job.yaml
@@ -27,7 +27,7 @@ spec:
 
       containers:
         - name: crd-applier
-          image: artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.32.2
+          image: artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.24.17
           command: ['/bin/sh', '-c']
           args:
             - |

--- a/charts/cray-metallb/templates/post-install-generate-crds-job.yaml
+++ b/charts/cray-metallb/templates/post-install-generate-crds-job.yaml
@@ -33,7 +33,7 @@ spec:
 
       initContainers:
         - name: fetch-customizations
-          image: artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.32.2
+          image: artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.24.17
           command: ['/bin/sh', '-c']
           args:
             - |


### PR DESCRIPTION
## Summary and Scope

During cray-metallb chart upgrades, the `cray-metallb-generate-crds` job failed with `ImagePullBackOff`. This occurred because the job required the `docker-kubectl:1.32.2` image from Artifactory, but the MetalLB upgrade process itself temporarily disabled the external LoadBalancer IPs needed to reach Artifactory, creating a dependency loop.

This change reverts the image used by metallb jobs to `docker-kubectl:1.24.17`. This version is already used elsewhere and is confirmed to be pre-cached on the nodes. Using the pre-cached image avoids the reliance on external network access during the upgrade, resolving the failure.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-7504](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7504)

## Risks and Mitigations

Low

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

