### PR TITLE
CASMTRIAGE-8214: Generate unique peer names

### DIFF
--- a/charts/cray-metallb/Chart.yaml
+++ b/charts/cray-metallb/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-metallb
-version: 2.0.0
+version: 2.0.1
 description: MetalLB is a load-balancer implementation for bare metal Kubernetes clusters
 home: https://github.com/Cray-HPE/cray-metallb
 dependencies:

--- a/charts/cray-metallb/files/generate_metallb_crds.py
+++ b/charts/cray-metallb/files/generate_metallb_crds.py
@@ -79,21 +79,7 @@ def generate_metallb_crds(customizations_yaml_path):
         }
         crd_yamls.append(yaml.dump(bgp_adv_node_mgmt))
 
-    if cmn_peers:
-        bgp_adv_customer_mgmt = {
-            'apiVersion': 'metallb.io/v1beta1',
-            'kind': 'BGPAdvertisement',
-            'metadata': {
-                'name': 'customer-management',
-                'namespace': 'metallb-system'
-            },
-            'spec': {
-                'ipAddressPools': ['customer-management-static', 'customer-management'],
-                'peers': cmn_peers
-            }
-        }
-        crd_yamls.append(yaml.dump(bgp_adv_customer_mgmt))
-
+    cmn_networks = ['customer-management-static', 'customer-management']
     if chn_peers:
         bgp_adv_customer_high_speed = {
             'apiVersion': 'metallb.io/v1beta1',
@@ -108,6 +94,23 @@ def generate_metallb_crds(customizations_yaml_path):
             }
         }
         crd_yamls.append(yaml.dump(bgp_adv_customer_high_speed))
+    else:
+        cmn_networks.append('customer-access')
+
+    if cmn_peers:
+        bgp_adv_customer_mgmt = {
+            'apiVersion': 'metallb.io/v1beta1',
+            'kind': 'BGPAdvertisement',
+            'metadata': {
+                'name': 'customer-management',
+                'namespace': 'metallb-system'
+            },
+            'spec': {
+                'ipAddressPools': cmn_networks,
+                'peers': cmn_peers
+            }
+        }
+        crd_yamls.append(yaml.dump(bgp_adv_customer_mgmt))
 
     return '---\n'.join(crd_yamls)
 

--- a/charts/cray-metallb/files/generate_metallb_crds.py
+++ b/charts/cray-metallb/files/generate_metallb_crds.py
@@ -95,6 +95,7 @@ def generate_metallb_crds(customizations_yaml_path):
         }
         crd_yamls.append(yaml.dump(bgp_adv_customer_high_speed))
     else:
+        # If no chn peers, we then need to advertise the customer-access pool
         cmn_networks.append('customer-access')
 
     if cmn_peers:

--- a/charts/cray-metallb/files/generate_metallb_crds.py
+++ b/charts/cray-metallb/files/generate_metallb_crds.py
@@ -12,7 +12,7 @@ def generate_metallb_crds(customizations_yaml_path):
 
     for peer in bgp_peers:
         peer_ip = peer['peer-address']
-        peer_name = peer.get('peer-name')
+        peer_name = f"{peer.get('device-name')}-{peer.get('device-network')}"
 
         if peer_name is None:
             print(f"Warning: Could not determine peer name for IP {peer_ip}.")
@@ -55,7 +55,7 @@ def generate_metallb_crds(customizations_yaml_path):
     chn_peers = []
 
     for peer in bgp_peers:
-        peer_name = peer.get('device-name')
+        peer_name = f"{peer.get('device-name')}-{peer.get('device-network')}"
         device_network = peer.get('device-network')
         if device_network == 'nmn':
             nmn_peers.append(peer_name)


### PR DESCRIPTION
## Summary and Scope

This change addresses a bug in the generate_metallb_crds.py script that resulted in an incomplete set of MetalLB BGPPeer resources, causing BGP connectivity to fail as not all peers were being established. Previously, using only device-name from the customizations.yaml for naming BGPPeer resources led to name collisions and incorrect configurations when a single physical peer device was associated with multiple networks (e.g., CMN and NMN). This update modifies the script to generate unique metadata.name for each BGPPeer by incorporating both the device-name and device-network, ensuring all distinct peer configurations defined in customizations.yaml are correctly translated into unique Kubernetes resources, enabling the proper setup of all required BGP sessions.

## Issues and Related PRs

* Resolves [CASMTRIAGE-8214](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8214)

## Testing

### Tested on:

  * `fanta`

### Test description:

```
helm install cray-metallb -n metallb-system ./cray-metallb-2.0.0.tgz -f values.yaml --debug
```

```
fanta-pit:/home/mcdonald/cray-metallb # kubectl get bgppeers -n metallb-system
NAME               ADDRESS      ASN     BFD PROFILE   MULTI HOPS
sw-spine-001-cmn   10.102.4.2   65533
sw-spine-001-nmn   10.252.0.2   65533
sw-spine-002-cmn   10.102.4.3   65533
sw-spine-002-nmn   10.252.0.3   65533
fanta-pit:/home/mcdonald/cray-metallb # kubectl get ipaddresspools -n metallb-system
NAME                         AUTO ASSIGN   AVOID BUGGY IPS   ADDRESSES
customer-access              true          false             ["10.102.4.160/27"]
customer-management          true          false             ["10.102.4.64/26"]
customer-management-static   true          false             ["10.102.4.60/30"]
hardware-management          true          false             ["10.94.100.0/24"]
node-management              true          false             ["10.92.100.0/24"]
fanta-pit:/home/mcdonald/cray-metallb # kubectl get bgpadvertisements -n metallb-systemNAME                  IPADDRESSPOOLS                                         IPADDRESSPOOL SELECTORS   PEERS
customer-management   ["customer-management-static","customer-management"]                             ["sw-spine-001-cmn","sw-spine-002-cmn"]
node-management       ["node-management","hardware-management"]                                        ["sw-spine-001-nmn","sw-spine-002-nmn"]
```

And then I confirmed that we are now correctly assigning IP addresses with this test service:

```
apiVersion: v1
kind: Service
metadata:
  name: test-service
  namespace: default
spec:
  selector:
    app: test-app
  ports:
    - protocol: TCP
      port: 80
      targetPort: 80
  type: LoadBalancer 
```

Which correctly gets an IP address assigned:

```
fanta-pit:/home/mcdonald # kubectl apply -f test-service.yaml
service/test-service created
fanta-pit:/home/mcdonald # kubectl get svc test-service
NAME           TYPE           CLUSTER-IP     EXTERNAL-IP    PORT(S)        AGE
test-service   LoadBalancer   10.29.93.158   10.102.4.162   80:30468/TCP   10s  
```

## Risks and Mitigations

Low


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

