### PR TITLE
Casmpet 7561: Generate dummy peer names if they don't exist in customizations

### DIFF
--- a/charts/cray-metallb/Chart.yaml
+++ b/charts/cray-metallb/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-metallb
-version: 2.0.1
+version: 2.0.2
 description: MetalLB is a load-balancer implementation for bare metal Kubernetes clusters
 home: https://github.com/Cray-HPE/cray-metallb
 dependencies:


### PR DESCRIPTION
## Summary and Scope

This PR changes the behavior of peer generation, where if the device-name or device-network are not found in customizations.yaml, then we will just name the peers `unknown-peer#`and assign it to the NMN network, so that people can manually configure after. This makes it so that it will not fail, preventing installs, if the values are missing.

## Issues and Related PRs

* Resolves [CASMPET-7561](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7561)

## Testing

### Tested on:

  * `beau`

### Test description:

Reproduced on Beau with 2.0.1:

```
#kubectl logs cray-metallb-apply-crds-4p5mj -n metallb-system
Error from server (Invalid): error when creating "/shared-data/generated-crds.yaml": BGPPeer.metallb.io "None-None" is invalid: metadata.name: Invalid value: "None-None": a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9][a-z0-9])?(\.[a-z0-9]([-a-z0-9][a-z0-9])?)*')
Error from server (Invalid): error when creating "/shared-data/generated-crds.yaml": BGPPeer.metallb.io "None-None" is invalid: metadata.name: Invalid value: "None-None": a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9][a-z0-9])?(\.[a-z0-9]([-a-z0-9][a-z0-9])?)*')
Error from server (Invalid): error when creating "/shared-data/generated-crds.yaml": BGPPeer.metallb.io "None-None" is invalid: metadata.name: Invalid value: "None-None": a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9][a-z0-9])?(\.[a-z0-9]([-a-z0-9][a-z0-9])?)*')
Error from server (Invalid): error when creating "/shared-data/generated-crds.yaml": BGPPeer.metallb.io "None-None" is invalid: metadata.name: Invalid value: "None-None": a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9][a-z0-9])?(\.[a-z0-9]([-a-z0-9][a-z0-9])?)*')
```

And then the new passing test, showing the generated peers:
```
kubectl get bgppeers -n metallb-system
NAME            ADDRESS      ASN     BFD PROFILE   MULTI HOPS
unknown-peer1   10.103.5.2   65533
unknown-peer2   10.103.5.3   65533
unknown-peer3   10.252.0.2   65533
unknown-peer4   10.252.0.3   65533
```

## Risks and Mitigations

None


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

