### PR TITLE
CASMPET-7579: Increase backoffLimit for post-install job

### DIFF
--- a/charts/cray-metallb/Chart.yaml
+++ b/charts/cray-metallb/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-metallb
-version: 2.0.2
+version: 2.0.3
 description: MetalLB is a load-balancer implementation for bare metal Kubernetes clusters
 home: https://github.com/Cray-HPE/cray-metallb
 dependencies:

--- a/charts/cray-metallb/templates/post-install-apply-crds-job.yaml
+++ b/charts/cray-metallb/templates/post-install-apply-crds-job.yaml
@@ -50,4 +50,5 @@ spec:
             - name: shared-data-volume
               mountPath: /shared-data
               readOnly: true
-  backoffLimit: 1
+  backoffLimit: 10
+  activeDeadlineSeconds: 600


### PR DESCRIPTION
## Summary and Scope

A timing issue caused this to fail in a CSM 1.7 install, where the CRDs weren't generated before applying the CRDs

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-7579](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7579)

## Risks and Mitigations

Low


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

